### PR TITLE
Validate links with travis & awesomebot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 2.2
+before_script:
+  - gem install awesome_bot
+script:
+  - awesome_bot README.md --allow-redirect --white-list axure,education.github.com

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Table of Contents
 
 ## Domain Name Registers
 
-  * [NameCheap](nic.me) - One year domain name registration on the .me TLD (normally $8.99/year) via [Github Student Developer Pack](https://education.github.com/pack).
+  * [NameCheap](http://nic.me) - One year domain name registration on the .me TLD (normally $8.99/year) via [Github Student Developer Pack](https://education.github.com/pack).
 
 ## Security
 
@@ -123,4 +123,4 @@ Table of Contents
 
 [![CC0](http://i.creativecommons.org/p/zero/1.0/88x31.png)](http://creativecommons.org/publicdomain/zero/1.0/)
 
-To the extent possible under law, [Acho Arnold](https://acho.arnold.cf) has waived all copyright and related or neighboring rights to this work.
+To the extent possible under law, [Acho Arnold](https://github.com/najela) has waived all copyright and related or neighboring rights to this work.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Table of Contents
 
 ## PaaS
 
-  * [Amazon Web Services](https://www.awseducate.com/application) - Access cloud content, training, collaboration tools, and AWS technology at no cost by joining AWS Educate today.
+  * [Amazon Web Services](http://www.awseducate.com/application) - Access cloud content, training, collaboration tools, and AWS technology at no cost by joining AWS Educate today.
 
 ## Emails
 


### PR DESCRIPTION
This adds the setup needed to run awesomebot on travis in order to validate links in the `README.md`.

This also corrects some links that were being detected as not valid. Those links were:

__acho.arnold.cf__:  @najela, your home page doesn't appear to operational anymore. so I updated it with your github profile
__axure.com__: due to some error with the site or awesomebot/faraday, this url was being deemed invalid. but it appears to be valid when i inspect it in a browser & with curl. so this was just whitelisted as opposed to diving deep into awesomebot, which seems out of the scope of this project.
__awseducate__:  due to some error with the site or awesomebot/faraday, the ssl on the site was being deemed invalid. but it appears to be valid when i inspect it in a browser & with curl. so this was just changed to the non-ssl link as opposed to diving deep into awesomebot, which seems out of the scope of this project. the non-ssl link redirects to the ssl link anyway. 

Hopefully the commit messages give enough info on the quirkiness of those sites. 

Closes #19 

NINJA EDIT: @najela, you'll have to set up [travis](travis.org) for this repo since you are the owner. It's pretty simple. For an example of how this will look once you do, you can check out the test PR I made on my fork when I was confirming that it worked. colbywhite/discount-for-student-dev#1 